### PR TITLE
Fix buy-in button staying visible after declining (#3)

### DIFF
--- a/client/src/api/game.ts
+++ b/client/src/api/game.ts
@@ -4,6 +4,7 @@ export interface GamePlayer {
   is_active: boolean;
   buy_ins: number;
   total_score: number;
+  can_buy_in: boolean;
 }
 
 export interface RoundScore {

--- a/client/src/components/Scoreboard.tsx
+++ b/client/src/components/Scoreboard.tsx
@@ -70,11 +70,11 @@ export default function Scoreboard({
     ? players.find((p) => p.player_id === game.winner_player_id)
     : null;
 
-  // Buy-in allowed if: game active, player is out, and at least 2 players still active
+  // Buy-in allowed if: game active, server says can_buy_in, and at least 2 players still active
   const canBuyIn = (playerId: string) => {
     if (!isActive) return false;
     const player = players.find((p) => p.player_id === playerId);
-    if (!player || player.is_active) return false;
+    if (!player || !player.can_buy_in) return false;
     return activePlayers.length >= 2;
   };
 

--- a/server/src/db/schema.sql
+++ b/server/src/db/schema.sql
@@ -28,8 +28,11 @@ CREATE TABLE IF NOT EXISTS game_players (
   is_active BOOLEAN NOT NULL DEFAULT true,
   buy_ins INT NOT NULL DEFAULT 0,
   total_score INT NOT NULL DEFAULT 0,
+  can_buy_in BOOLEAN NOT NULL DEFAULT false,
   PRIMARY KEY (game_id, player_id)
 );
+
+ALTER TABLE game_players ADD COLUMN IF NOT EXISTS can_buy_in BOOLEAN NOT NULL DEFAULT false;
 
 CREATE TABLE IF NOT EXISTS rounds (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -86,11 +86,26 @@ router.post("/games/:gameId/finish-round", async (req: Request, res: Response) =
       );
     }
 
-    // Check eliminations: players at >= 15 who are still active
+    // Reset can_buy_in for all players at the start of the round
     await client.query(
-      "UPDATE game_players SET is_active = false WHERE game_id = $1 AND total_score >= 15 AND is_active = true",
+      "UPDATE game_players SET can_buy_in = false WHERE game_id = $1",
       [gameId]
     );
+
+    // Check eliminations: players at >= 15 who are still active
+    const eliminatedRes = await client.query(
+      "UPDATE game_players SET is_active = false WHERE game_id = $1 AND total_score >= 15 AND is_active = true RETURNING player_id",
+      [gameId]
+    );
+
+    // Allow just-eliminated players to buy in
+    if (eliminatedRes.rows.length > 0) {
+      const eliminatedIds = eliminatedRes.rows.map((r: { player_id: string }) => r.player_id);
+      await client.query(
+        `UPDATE game_players SET can_buy_in = true WHERE game_id = $1 AND player_id = ANY($2)`,
+        [gameId, eliminatedIds]
+      );
+    }
 
     // Check if game should auto-finish (0 active players left — everyone eliminated at once)
     const activeRes = await client.query(
@@ -146,9 +161,9 @@ router.post("/games/:gameId/buy-in", async (req: Request, res: Response) => {
       return;
     }
 
-    // Verify player is eliminated
+    // Verify player is eliminated and can buy in
     const gpRes = await client.query(
-      "SELECT is_active, total_score FROM game_players WHERE game_id = $1 AND player_id = $2",
+      "SELECT is_active, total_score, can_buy_in FROM game_players WHERE game_id = $1 AND player_id = $2",
       [gameId, playerId]
     );
     if (gpRes.rows.length === 0) {
@@ -158,6 +173,11 @@ router.post("/games/:gameId/buy-in", async (req: Request, res: Response) => {
     }
     if (gpRes.rows[0].is_active) {
       res.status(400).json({ error: "Speler is nog actief" });
+      await client.query("ROLLBACK");
+      return;
+    }
+    if (!gpRes.rows[0].can_buy_in) {
+      res.status(400).json({ error: "Inkopen is niet meer mogelijk" });
       await client.query("ROLLBACK");
       return;
     }
@@ -182,9 +202,9 @@ router.post("/games/:gameId/buy-in", async (req: Request, res: Response) => {
     const oldScore = Number(gpRes.rows[0].total_score);
     const adjustment = buyInScore - oldScore;
 
-    // Reactivate at the highest active player's score, increment buy_ins
+    // Reactivate at the highest active player's score, increment buy_ins, clear can_buy_in
     await client.query(
-      "UPDATE game_players SET is_active = true, total_score = $1, buy_ins = buy_ins + 1 WHERE game_id = $2 AND player_id = $3",
+      "UPDATE game_players SET is_active = true, total_score = $1, buy_ins = buy_ins + 1, can_buy_in = false WHERE game_id = $2 AND player_id = $3",
       [buyInScore, gameId, playerId]
     );
 

--- a/server/src/services/game.ts
+++ b/server/src/services/game.ts
@@ -6,6 +6,7 @@ export interface GamePlayer {
   is_active: boolean;
   buy_ins: number;
   total_score: number;
+  can_buy_in: boolean;
 }
 
 export interface RoundScore {
@@ -53,7 +54,7 @@ export async function getFullGameState(
 
   // Get game players
   const playersRes = await pool.query(
-    `SELECT gp.player_id, p.name as player_name, gp.is_active, gp.buy_ins, gp.total_score
+    `SELECT gp.player_id, p.name as player_name, gp.is_active, gp.buy_ins, gp.total_score, gp.can_buy_in
      FROM game_players gp
      JOIN players p ON p.id = gp.player_id
      WHERE gp.game_id = $1


### PR DESCRIPTION
Add server-managed can_buy_in flag to game_players so the buy-in window closes after the next round starts, instead of persisting for all eliminated players indefinitely.