### PR TITLE
Improve landscape mobile layout for scoring view (#14)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,7 +10,6 @@ export default function App() {
         <header className="app-header">
           <img src={headerIcon} alt="Four 10s" className="header-icon" />
           <h1>toepify</h1>
-          <div className="subtitle">Score Tracker</div>
         </header>
         <Routes>
           <Route path="/admin" element={<AdminPage />} />

--- a/client/src/components/Scoreboard.tsx
+++ b/client/src/components/Scoreboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useEffect, useRef } from "react";
 import type { GameState } from "../api/game";
 
 function getUniqueAbbreviations(names: string[]): Map<string, string> {
@@ -99,6 +99,21 @@ export default function Scoreboard({
     cumulativeScores.push({ ...runningTotals });
   }
 
+  // Split cumulative scores into history (scrollable) and current (always visible)
+  const historyScores = cumulativeScores.slice(0, -1);
+  const currentScores: Record<string, number> =
+    cumulativeScores.length > 0
+      ? cumulativeScores[cumulativeScores.length - 1]
+      : Object.fromEntries(players.map((p) => [p.player_id, 0]));
+
+  // Auto-scroll history to bottom so most recent rounds are visible
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [historyScores.length]);
+
   const formatEuro = (amount: number) => {
     const formatted = Math.abs(amount).toFixed(2).replace(".", ",");
     if (amount >= 0) return `+€${formatted}`;
@@ -107,14 +122,6 @@ export default function Scoreboard({
 
   return (
     <div className="scoreboard">
-      {/* Header */}
-      <div className="scoreboard-header">
-        <div className="scoreboard-title">{tournament.name}</div>
-        <div className="pot-display">
-          Pot: €{pot.toFixed(2).replace(".", ",")}
-        </div>
-      </div>
-
       {/* Winner banner */}
       {winner && (
         <div className="winner-banner">
@@ -124,7 +131,8 @@ export default function Scoreboard({
 
       {/* Score table */}
       <div className="score-table-wrapper">
-        <table className="score-table">
+        {/* Player header */}
+        <table className="score-table score-table-fixed">
           <thead>
             <tr>
               {players.map((p) => (
@@ -142,39 +150,61 @@ export default function Scoreboard({
               ))}
             </tr>
           </thead>
-          <tbody>
-            {cumulativeScores.map((scores, i) => {
-              const isCurrent = i === cumulativeScores.length - 1;
-              return (
-                <tr key={i} className={isCurrent ? "score-row-current" : "score-row-history"}>
-                  {players.map((p) => {
-                    const val = scores[p.player_id] || 0;
-                    return (
-                      <td
-                        key={p.player_id}
-                        className={
-                          val >= 15
-                            ? "score-cell score-out"
-                            : val === 14
-                            ? "score-cell score-pelt"
-                            : "score-cell"
-                        }
-                      >
-                        {val}
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
-            {/* Empty state */}
-            {rounds.length === 0 && (
-              <tr>
-                {players.map((p) => (
-                  <td key={p.player_id} className="score-cell">0</td>
+        </table>
+
+        {/* Scrollable history rows */}
+        {historyScores.length > 0 && (
+          <div className="score-table-scroll" ref={scrollRef}>
+            <table className="score-table score-table-fixed">
+              <tbody>
+                {historyScores.map((scores, i) => (
+                  <tr key={i} className="score-row-history">
+                    {players.map((p) => {
+                      const val = scores[p.player_id] || 0;
+                      return (
+                        <td
+                          key={p.player_id}
+                          className={
+                            val >= 15
+                              ? "score-cell score-out"
+                              : val === 14
+                              ? "score-cell score-pelt"
+                              : "score-cell"
+                          }
+                        >
+                          {val}
+                        </td>
+                      );
+                    })}
+                  </tr>
                 ))}
-              </tr>
-            )}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Current score row — always visible */}
+        <table className="score-table score-table-fixed">
+          <tbody>
+            <tr className="score-row-current">
+              {players.map((p) => {
+                const val = currentScores[p.player_id] || 0;
+                return (
+                  <td
+                    key={p.player_id}
+                    className={
+                      val >= 15
+                        ? "score-cell score-out"
+                        : val === 14
+                        ? "score-cell score-pelt"
+                        : "score-cell"
+                    }
+                  >
+                    {val}
+                  </td>
+                );
+              })}
+            </tr>
           </tbody>
         </table>
       </div>
@@ -263,36 +293,52 @@ export default function Scoreboard({
         </button>
       )}
 
+      {/* Tournament info */}
+      <div className="scoreboard-header">
+        <div className="scoreboard-title">{tournament.name}</div>
+        <div className="pot-display">
+          Pot: €{pot.toFixed(2).replace(".", ",")}
+        </div>
+      </div>
+
       {/* Player summary table */}
       <div className="player-summary-wrapper">
         <table className="player-summary-table">
           <thead>
             <tr>
+              <th className="pos-col">#</th>
               <th>Speler</th>
               <th>Balans</th>
               <th>Inzet</th>
             </tr>
           </thead>
           <tbody>
-            {players.map((p) => {
-              const balance = balances.find((b) => b.player_id === p.player_id);
-              const stake = tournament.stake_per_game * (1 + p.buy_ins);
-              return (
-                <tr key={p.player_id}>
-                  <td>{p.player_name}</td>
-                  <td className={
-                    balance && balance.balance > 0
-                      ? "balance-positive"
-                      : balance && balance.balance < 0
-                      ? "balance-negative"
-                      : ""
-                  }>
-                    {balance ? formatEuro(balance.balance) : "€0,00"}
-                  </td>
-                  <td>€{stake.toFixed(2).replace(".", ",")}</td>
-                </tr>
-              );
-            })}
+            {[...players]
+              .sort((a, b) => {
+                const balA = balances.find((bl) => bl.player_id === a.player_id)?.balance ?? 0;
+                const balB = balances.find((bl) => bl.player_id === b.player_id)?.balance ?? 0;
+                return balB - balA;
+              })
+              .map((p, index) => {
+                const balance = balances.find((b) => b.player_id === p.player_id);
+                const stake = tournament.stake_per_game * (1 + p.buy_ins);
+                return (
+                  <tr key={p.player_id}>
+                    <td className="pos-col">{index + 1}</td>
+                    <td>{p.player_name}</td>
+                    <td className={
+                      balance && balance.balance > 0
+                        ? "balance-positive"
+                        : balance && balance.balance < 0
+                        ? "balance-negative"
+                        : ""
+                    }>
+                      {balance ? formatEuro(balance.balance) : "€0,00"}
+                    </td>
+                    <td>€{stake.toFixed(2).replace(".", ",")}</td>
+                  </tr>
+                );
+              })}
           </tbody>
         </table>
       </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -44,9 +44,12 @@ body {
 
 /* Header */
 .app-header {
-  text-align: center;
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
   border-bottom: 2px solid var(--accent);
 }
 
@@ -60,16 +63,7 @@ body {
 }
 
 .app-header .header-icon {
-  height: 56px;
-  margin-bottom: 0.5rem;
-}
-
-.app-header .subtitle {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  color: var(--text-muted);
-  margin-top: 0.25rem;
+  height: 36px;
 }
 
 /* Cards */
@@ -352,10 +346,20 @@ fieldset legend {
   overflow-x: auto;
 }
 
+.score-table-scroll {
+  max-height: calc(3 * 2rem);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .score-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.9rem;
+  table-layout: fixed;
+}
+
+.score-table-fixed {
   table-layout: fixed;
 }
 
@@ -661,4 +665,10 @@ fieldset legend {
   padding: 0.4rem 0.5rem;
   border-bottom: 1px solid var(--border);
   font-variant-numeric: tabular-nums;
+}
+
+.player-summary-table .pos-col {
+  width: 2rem;
+  text-align: center;
+  color: var(--text-muted);
 }


### PR DESCRIPTION
- Remove 'Score Tracker' subtitle, inline icon + title in header
- Move tournament name and pot display above the leaderboard
- Make score history scrollable (3 rows visible), current score always visible
- Sort leaderboard by balance descending and add position column

Closes #14 