### PR TITLE
Fix buy-in button double-click and show full player name

### DIFF
--- a/client/src/components/Scoreboard.tsx
+++ b/client/src/components/Scoreboard.tsx
@@ -49,6 +49,7 @@ interface ScoreboardProps {
   finishingRound: boolean;
   onCancelRound: () => void;
   onBuyIn: (playerId: string) => void;
+  buyingIn: boolean;
   onNewGame: () => void;
 }
 
@@ -60,6 +61,7 @@ export default function Scoreboard({
   finishingRound,
   onCancelRound,
   onBuyIn,
+  buyingIn,
   onNewGame,
 }: ScoreboardProps) {
   const { tournament, game, players, rounds, pot, balances } = gameState;
@@ -216,9 +218,10 @@ export default function Scoreboard({
                 <button
                   key={p.player_id}
                   className="btn-primary btn-buyin"
+                  disabled={buyingIn}
                   onClick={() => onBuyIn(p.player_id)}
                 >
-                  {abbreviations.get(p.player_name)} inkopen op {maxActiveScore} (€{tournament.stake_per_game.toFixed(2).replace(".", ",")})
+                  {p.player_name} inkopen op {maxActiveScore} (€{tournament.stake_per_game.toFixed(2).replace(".", ",")})
                 </button>
               );
             })}

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -26,6 +26,7 @@ export default function TournamentPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [finishingRound, setFinishingRound] = useState(false);
+  const [buyingIn, setBuyingIn] = useState(false);
 
   // Load initial state and set up socket
   useEffect(() => {
@@ -134,15 +135,18 @@ export default function TournamentPage() {
 
   const handleBuyIn = useCallback(
     async (playerId: string) => {
-      if (!gameState) return;
+      if (!gameState || buyingIn) return;
+      setBuyingIn(true);
       try {
         const newState = await buyIn(gameState.game.id, playerId);
         setGameState(newState);
       } catch (err: unknown) {
         setError(err instanceof Error ? err.message : "Fout bij inkopen");
+      } finally {
+        setBuyingIn(false);
       }
     },
-    [gameState]
+    [gameState, buyingIn]
   );
 
   const handleCancelRound = useCallback(() => {
@@ -184,6 +188,7 @@ export default function TournamentPage() {
       finishingRound={finishingRound}
       onCancelRound={handleCancelRound}
       onBuyIn={handleBuyIn}
+      buyingIn={buyingIn}
       onNewGame={handleNewGame}
     />
   );


### PR DESCRIPTION
Disable the buy-in button while the request is in flight to prevent double submissions leading to incorrect scores. Also display the full player name on the button instead of the abbreviation.

Closes #11 