### PR TITLE
Update celebration end screen stats

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Link, useNavigate } from "react-router-dom";
-import { AuthProvider, useAuth } from "./contexts/AuthContext";
+import { AuthProvider } from "./contexts/AuthContext";
+import { useAuth } from "./contexts/useAuth";
 import AdminPage from "./pages/AdminPage";
 import TournamentPage from "./pages/TournamentPage";
 import LandingPage from "./pages/LandingPage";

--- a/client/src/api/game.ts
+++ b/client/src/api/game.ts
@@ -14,6 +14,7 @@ export interface RoundScore {
 
 export interface Round {
   round_number: number;
+  round_type?: "normal" | "buy_in";
   scores: RoundScore[];
 }
 

--- a/client/src/api/socket.ts
+++ b/client/src/api/socket.ts
@@ -30,7 +30,7 @@ export function onNewGameStarted(callback: (data: { gameId: string; tournamentId
   connectSocket().on("new_game_started", callback);
 }
 
-export function leaveGame(_gameId: string) {
+export function leaveGame() {
   const s = connectSocket();
   s.off("game_state");
   s.off("round_penalty_updated");

--- a/client/src/components/CreateTournament.tsx
+++ b/client/src/components/CreateTournament.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "../contexts/useAuth";
 import { createTournament } from "../api/tournaments";
 import type { Tournament } from "../api/tournaments";
 

--- a/client/src/components/GameEndCelebration.tsx
+++ b/client/src/components/GameEndCelebration.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { GameState } from "../api/game";
 import GameDramaGrid from "./GameDramaGrid";
+import { getMostPenaltyStat, getNormalRounds } from "./celebrationStats";
 
 interface GameEndCelebrationProps {
   gameState: GameState;
@@ -24,22 +25,12 @@ export default function GameEndCelebration({
   );
 
   const totalBuyIns = players.reduce((sum, p) => sum + p.buy_ins, 0);
-  const roundCount = rounds.length;
-
-  const mostPenalty = useMemo(() => {
-    let maxPoints = 0;
-    let maxPlayerName = "";
-    for (const round of rounds) {
-      for (const score of round.scores) {
-        if (score.penalty_points > maxPoints) {
-          maxPoints = score.penalty_points;
-          const player = players.find((p) => p.player_id === score.player_id);
-          maxPlayerName = player?.player_name ?? "";
-        }
-      }
-    }
-    return { name: maxPlayerName, points: maxPoints };
-  }, [rounds, players]);
+  const normalRounds = useMemo(() => getNormalRounds(rounds), [rounds]);
+  const roundCount = normalRounds.length;
+  const mostPenalty = useMemo(
+    () => getMostPenaltyStat(rounds, players),
+    [rounds, players]
+  );
 
   const sortedBalances = useMemo(
     () => [...balances].sort((a, b) => b.balance - a.balance),
@@ -52,17 +43,25 @@ export default function GameEndCelebration({
     return `-\u20AC${formatted}`;
   };
 
-  // Generate confetti pieces
+  const formatPot = (amount: number) =>
+    `\u20AC${amount.toFixed(2).replace(".", ",")}`;
+
+  // Generate deterministic confetti pieces so rendering remains pure.
   const confettiPieces = useMemo(() => {
     const colors = ["#e8a817", "#e74c3c", "#2ecc71", "#3498db", "#9b59b6", "#f39c12"];
+    const pseudoRandom = (seed: number) => {
+      const value = Math.sin(seed) * 10000;
+      return value - Math.floor(value);
+    };
+
     return Array.from({ length: 50 }, (_, i) => ({
       id: i,
-      left: `${Math.random() * 100}%`,
-      delay: `${Math.random() * 3}s`,
-      duration: `${2 + Math.random() * 3}s`,
+      left: `${pseudoRandom(i + 1) * 100}%`,
+      delay: `${pseudoRandom(i + 101) * 3}s`,
+      duration: `${2 + pseudoRandom(i + 201) * 3}s`,
       color: colors[i % colors.length],
-      size: 6 + Math.random() * 6,
-      isCircle: Math.random() > 0.5,
+      size: 6 + pseudoRandom(i + 301) * 6,
+      isCircle: pseudoRandom(i + 401) > 0.5,
     }));
   }, []);
 
@@ -90,37 +89,32 @@ export default function GameEndCelebration({
       <div className="celebration-winner">
         {winner?.player_name ?? "Winnaar"}
       </div>
-      <div className="celebration-subtitle">wint de pot!</div>
-
-      {/* Stats */}
-      <div className="celebration-stats">
-        <div className="stat-card">
-          <div className="stat-value">
-            {"\u20AC"}
-            {pot.toFixed(2).replace(".", ",")}
-          </div>
-          <div className="stat-label">Pot</div>
-        </div>
-        <div className="stat-card">
-          <div className="stat-value">{totalBuyIns}</div>
-          <div className="stat-label">Inkopen</div>
-        </div>
-        <div className="stat-card">
-          <div className="stat-value">{roundCount}</div>
-          <div className="stat-label">Rondes</div>
-        </div>
-        {mostPenalty.points > 0 && (
-          <div className="stat-card">
-            <div className="stat-value">{mostPenalty.name}</div>
-            <div className="stat-label">
-              Meeste punten in een ronde ({mostPenalty.points})
-            </div>
-          </div>
-        )}
+      <div className="celebration-subtitle">
+        wint de pot: <span>{formatPot(pot)}</span>
       </div>
 
+      {/* Stats */}
+      <dl className="celebration-stats" aria-label="Spelstatistieken">
+        <div className="celebration-stat-row">
+          <dt>Aantal inkopen</dt>
+          <dd>{totalBuyIns}</dd>
+        </div>
+        <div className="celebration-stat-row">
+          <dt>Meeste punten in 1 ronde</dt>
+          <dd>
+            {mostPenalty.points > 0
+              ? `${mostPenalty.points} (${mostPenalty.playerNames.join(", ")})`
+              : "0"}
+          </dd>
+        </div>
+        <div className="celebration-stat-row">
+          <dt>Aantal ronden</dt>
+          <dd>{roundCount}</dd>
+        </div>
+      </dl>
+
       {/* Drama grid */}
-      {rounds.length > 0 && (
+      {normalRounds.length > 0 && (
         <GameDramaGrid gameState={gameState} excludedPlayers={excludedPlayers} />
       )}
 

--- a/client/src/components/buildDramaGridData.ts
+++ b/client/src/components/buildDramaGridData.ts
@@ -1,4 +1,5 @@
 import type { GamePlayer, Round } from "../api/game";
+import { isBuyInRound } from "./celebrationStats";
 
 export type CellEvent = "none" | "pelt" | "eliminated" | "buyin" | "dead" | "winner";
 
@@ -54,9 +55,9 @@ export function buildDramaGridData(
     const scoresByPlayer = new Map(
       round.scores.map((s) => [s.player_id, s.penalty_points])
     );
-    const isBuyInRound = round.scores.some((s) => s.penalty_points < 0);
+    const isBuyIn = isBuyInRound(round);
 
-    if (isBuyInRound) {
+    if (isBuyIn) {
       // Don't create a column. Retroactively mark the buying-in player's last
       // non-dead cell with "buyin" and update their running total.
       for (const p of players) {

--- a/client/src/components/celebrationStats.test.ts
+++ b/client/src/components/celebrationStats.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { GamePlayer, Round } from "../api/game";
+import { getMostPenaltyStat, getNormalRounds } from "./celebrationStats";
+
+function makePlayer(id: string, name: string): GamePlayer {
+  return {
+    player_id: id,
+    player_name: name,
+    is_active: true,
+    buy_ins: 0,
+    total_score: 0,
+    can_buy_in: false,
+  };
+}
+
+function makeRound(
+  roundNumber: number,
+  scores: Record<string, number>,
+  roundType?: Round["round_type"]
+): Round {
+  return {
+    round_number: roundNumber,
+    round_type: roundType,
+    scores: Object.entries(scores).map(([player_id, penalty_points]) => ({
+      player_id,
+      penalty_points,
+    })),
+  };
+}
+
+const players = [
+  makePlayer("a", "Alice"),
+  makePlayer("b", "Bob"),
+  makePlayer("c", "Charlie"),
+];
+
+describe("celebration stats", () => {
+  it("counts only normal rounds", () => {
+    const rounds = [
+      makeRound(1, { a: 2, b: 0 }, "normal"),
+      makeRound(2, { a: -3 }, "buy_in"),
+      makeRound(3, { a: 1, b: 4 }, "normal"),
+    ];
+
+    expect(getNormalRounds(rounds)).toHaveLength(2);
+  });
+
+  it("falls back to negative scores to identify legacy buy-in rounds", () => {
+    const rounds = [
+      makeRound(1, { a: 2, b: 0 }),
+      makeRound(2, { a: -3 }),
+    ];
+
+    expect(getNormalRounds(rounds)).toHaveLength(1);
+  });
+
+  it("returns all players tied for most points in one normal round", () => {
+    const rounds = [
+      makeRound(1, { a: 4, b: 2, c: 0 }, "normal"),
+      makeRound(2, { a: -2 }, "buy_in"),
+      makeRound(3, { a: 1, b: 4, c: 4 }, "normal"),
+    ];
+
+    expect(getMostPenaltyStat(rounds, players)).toEqual({
+      points: 4,
+      playerNames: ["Alice", "Bob", "Charlie"],
+    });
+  });
+});

--- a/client/src/components/celebrationStats.ts
+++ b/client/src/components/celebrationStats.ts
@@ -1,0 +1,48 @@
+import type { GamePlayer, Round } from "../api/game";
+
+export interface MostPenaltyStat {
+  points: number;
+  playerNames: string[];
+}
+
+export function isBuyInRound(round: Round): boolean {
+  return (
+    round.round_type === "buy_in" ||
+    (round.round_type === undefined &&
+      round.scores.some((score) => score.penalty_points < 0))
+  );
+}
+
+export function getNormalRounds(rounds: Round[]): Round[] {
+  return rounds.filter((round) => !isBuyInRound(round));
+}
+
+export function getMostPenaltyStat(
+  rounds: Round[],
+  players: GamePlayer[]
+): MostPenaltyStat {
+  const playerNames = new Map(
+    players.map((player) => [player.player_id, player.player_name])
+  );
+  let points = 0;
+  const playerIds = new Set<string>();
+
+  for (const round of getNormalRounds(rounds)) {
+    for (const score of round.scores) {
+      if (score.penalty_points > points) {
+        points = score.penalty_points;
+        playerIds.clear();
+      }
+      if (score.penalty_points === points && points > 0) {
+        playerIds.add(score.player_id);
+      }
+    }
+  }
+
+  return {
+    points,
+    playerNames: Array.from(playerIds)
+      .map((playerId) => playerNames.get(playerId))
+      .filter((name): name is string => Boolean(name)),
+  };
+}

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,22 +1,11 @@
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react";
+import { useState, useEffect, useCallback, type ReactNode } from "react";
 import {
   loginWithCredentials,
   loginWithPin as apiLoginWithPin,
   fetchMe,
   type AuthUser,
 } from "../api/auth";
-
-interface AuthContextValue {
-  user: AuthUser | null;
-  token: string | null;
-  login(username: string, password: string): Promise<void>;
-  loginWithPin(pin: string): Promise<void>;
-  logout(): void;
-  isAuthenticated: boolean;
-  loading: boolean;
-}
-
-const AuthContext = createContext<AuthContextValue | null>(null);
+import { AuthContext } from "./authContextValue";
 
 const TOKEN_KEY = "toepify_auth_token";
 
@@ -26,10 +15,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(!!localStorage.getItem(TOKEN_KEY));
 
   useEffect(() => {
-    if (!token) {
-      setLoading(false);
-      return;
-    }
+    if (!token) return;
 
     fetchMe(token)
       .then((u) => {
@@ -78,10 +64,4 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       {children}
     </AuthContext.Provider>
   );
-}
-
-export function useAuth() {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
-  return ctx;
 }

--- a/client/src/contexts/authContextValue.ts
+++ b/client/src/contexts/authContextValue.ts
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+import type { AuthUser } from "../api/auth";
+
+export interface AuthContextValue {
+  user: AuthUser | null;
+  token: string | null;
+  login(username: string, password: string): Promise<void>;
+  loginWithPin(pin: string): Promise<void>;
+  logout(): void;
+  isAuthenticated: boolean;
+  loading: boolean;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/client/src/contexts/useAuth.ts
+++ b/client/src/contexts/useAuth.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { AuthContext } from "./authContextValue";
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -958,6 +958,11 @@ fieldset legend {
   animation: scale-in 0.6s 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
 }
 
+.celebration-subtitle span {
+  color: var(--accent);
+  font-weight: 700;
+}
+
 @keyframes scale-in {
   from {
     opacity: 0;
@@ -1001,42 +1006,44 @@ fieldset legend {
 
 /* Stats */
 .celebration-stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  justify-content: center;
-  margin-bottom: 1.5rem;
-  max-width: 400px;
+  width: 100%;
+  max-width: 460px;
+  margin: 0 0 1.5rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
   animation: scale-in 0.5s 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
 }
 
-.stat-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 0.6rem 1rem;
-  text-align: center;
-  min-width: 5rem;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+.celebration-stat-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(7rem, auto);
+  gap: 1rem;
   align-items: center;
-  justify-content: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
 }
 
-.stat-value {
-  font-size: 1.3rem;
-  font-weight: 700;
-  color: var(--accent);
-  font-variant-numeric: tabular-nums;
+.celebration-stat-row:last-child {
+  border-bottom: 0;
 }
 
-.stat-label {
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+.celebration-stat-row dt,
+.celebration-stat-row dd {
+  margin: 0;
+}
+
+.celebration-stat-row dt {
   color: var(--text-muted);
-  margin-top: 0.15rem;
+  font-weight: 600;
+}
+
+.celebration-stat-row dd {
+  color: var(--text);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
 }
 
 /* Drama grid */

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "../contexts/useAuth";
 import TournamentList from "../components/TournamentList";
 
 interface User {

--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -1,33 +1,9 @@
 import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "../contexts/useAuth";
 import CreateTournament from "../components/CreateTournament";
 import { fetchMyTournaments, deleteTournament, visitTournament, type MyTournament } from "../api/tournaments";
-
-interface RecentTournament {
-  id: string;
-  name: string;
-  players: string[];
-  lastVisited: number;
-}
-
-const STORAGE_KEY = "toepify_recent_tournaments";
-
-export function getRecentTournaments(): RecentTournament[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    return JSON.parse(raw) as RecentTournament[];
-  } catch {
-    return [];
-  }
-}
-
-export function saveRecentTournament(id: string, name: string, players: string[]) {
-  const existing = getRecentTournaments().filter((t) => t.id !== id);
-  const updated = [{ id, name, players, lastVisited: Date.now() }, ...existing].slice(0, 10);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-}
+import { getRecentTournaments, type RecentTournament } from "../utils/recentTournaments";
 
 function parseTournamentId(input: string): string {
   const trimmed = input.trim();

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "../contexts/useAuth";
 import { checkBootstrap } from "../api/auth";
 
 export default function LoginPage() {

--- a/client/src/pages/TournamentPage.tsx
+++ b/client/src/pages/TournamentPage.tsx
@@ -20,8 +20,8 @@ import {
 } from "../api/socket";
 import Scoreboard from "../components/Scoreboard";
 import TournamentClosed from "../components/TournamentClosed";
-import { saveRecentTournament, getRecentTournaments } from "./LandingPage";
-import { useAuth } from "../contexts/AuthContext";
+import { saveRecentTournament, getRecentTournaments } from "../utils/recentTournaments";
+import { useAuth } from "../contexts/useAuth";
 import { visitTournament, closeTournament, fetchSettlement, type SettlementData } from "../api/tournaments";
 
 export default function TournamentPage() {
@@ -101,7 +101,7 @@ export default function TournamentPage() {
 
     return () => {
       cancelled = true;
-      leaveGame("");
+      leaveGame();
       disconnectSocket();
     };
   }, [tournamentId]);
@@ -246,13 +246,15 @@ export default function TournamentPage() {
     }
   }, [tournamentId]);
 
+  const tournamentStatus = gameState?.tournament.status;
+
   // Fetch settlement data when tournament is closed
   useEffect(() => {
-    if (!gameState || gameState.tournament.status !== "closed" || !tournamentId) return;
+    if (tournamentStatus !== "closed" || !tournamentId) return;
     fetchSettlement(tournamentId)
       .then(setSettlementData)
       .catch(() => {});
-  }, [gameState?.tournament.status, tournamentId]);
+  }, [tournamentStatus, tournamentId]);
 
   const isCreator = !!(user && gameState && gameState.tournament.created_by === user.username);
 

--- a/client/src/utils/recentTournaments.ts
+++ b/client/src/utils/recentTournaments.ts
@@ -1,0 +1,24 @@
+export interface RecentTournament {
+  id: string;
+  name: string;
+  players: string[];
+  lastVisited: number;
+}
+
+const STORAGE_KEY = "toepify_recent_tournaments";
+
+export function getRecentTournaments(): RecentTournament[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as RecentTournament[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentTournament(id: string, name: string, players: string[]) {
+  const existing = getRecentTournaments().filter((t) => t.id !== id);
+  const updated = [{ id, name, players, lastVisited: Date.now() }, ...existing].slice(0, 10);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+}

--- a/server/src/services/game.ts
+++ b/server/src/services/game.ts
@@ -16,6 +16,7 @@ export interface RoundScore {
 
 export interface Round {
   round_number: number;
+  round_type: "normal" | "buy_in";
   scores: RoundScore[];
 }
 
@@ -199,7 +200,7 @@ export async function getFullGameState(
 
   // Get rounds with scores
   const roundsRes = await pool.query(
-    `SELECT r.round_number, rs.player_id, rs.penalty_points
+    `SELECT r.round_number, r.round_type, rs.player_id, rs.penalty_points
      FROM rounds r
      JOIN round_scores rs ON rs.round_id = r.id
      WHERE r.game_id = $1
@@ -207,19 +208,26 @@ export async function getFullGameState(
     [gameId]
   );
 
-  const roundsMap = new Map<number, RoundScore[]>();
+  const roundsMap = new Map<number, { round_type: "normal" | "buy_in"; scores: RoundScore[] }>();
   for (const row of roundsRes.rows) {
     if (!roundsMap.has(row.round_number)) {
-      roundsMap.set(row.round_number, []);
+      roundsMap.set(row.round_number, {
+        round_type: row.round_type === "buy_in" ? "buy_in" : "normal",
+        scores: [],
+      });
     }
-    roundsMap.get(row.round_number)!.push({
+    roundsMap.get(row.round_number)!.scores.push({
       player_id: row.player_id,
       penalty_points: row.penalty_points,
     });
   }
   const rounds: Round[] = Array.from(roundsMap.entries())
     .sort(([a], [b]) => a - b)
-    .map(([round_number, scores]) => ({ round_number, scores }));
+    .map(([round_number, round]) => ({
+      round_number,
+      round_type: round.round_type,
+      scores: round.scores,
+    }));
 
   // Compute pot
   const totalBuyIns = players.reduce((sum, p) => sum + p.buy_ins, 0);


### PR DESCRIPTION
### Motivation
- Improve the game-end celebration UI to show clearer statistics and to correctly exclude buy-in rounds from round-based stats.
- Ensure the client can reliably detect buy-in rounds by surfacing `round_type` from the server so legacy negative-score buy-ins are still supported.

### Description
- Expose `round_type` in the server `getFullGameState` response and update TypeScript types so rounds are annotated as `"normal" | "buy_in"`.
- Add `client/src/components/celebrationStats.ts` helpers to detect buy-in rounds, compute normal rounds, and compute the tied "most points in one round" stat, and use these in `GameEndCelebration` and the drama grid.
- Replace the stat cards in `GameEndCelebration` with an accessible definition-list layout that shows total pot in the subtitle, number of buy-ins, most points (with tied player names), and normal-round count, plus CSS updates in `client/src/index.css` and deterministic confetti generation.
- Small supportive refactors: moved recent-tournament helpers into `client/src/utils/recentTournaments.ts`, split auth context types into `authContextValue.ts`/`useAuth.ts`, updated `buildDramaGridData` to use the new buy-in detection, and adjusted socket `leaveGame()` signature.

### Testing
- Ran unit tests: server tests (Vitest) and client tests (Vitest) all passed (server: 78 tests, client: 25 tests) without failures.
- Ran frontend linting with `npm run lint -w client` which completed cleanly after refactors.
- Executed a production build (`npm run build`) for client and server and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da753617083249dfb7bb273d8798b)