### PR TITLE
Move Sloper/Snurker to top of stats and enhance Snurker details

### DIFF
--- a/client/src/components/CelebrationStatsOverlay.tsx
+++ b/client/src/components/CelebrationStatsOverlay.tsx
@@ -63,6 +63,16 @@ export default function CelebrationStatsOverlay({
   const formatNames = (names: string[]) =>
     names.length > 0 ? names.join(", ") : "-";
 
+  const formatSnurkers = () =>
+    snurker.players.length > 0
+      ? snurker.players
+          .map(
+            (player) =>
+              `${player.playerName} (${player.matchingRounds} keer van ${player.playedRounds} ronden)`
+          )
+          .join(", ")
+      : "-";
+
   // Generate deterministic confetti pieces so rendering remains pure.
   const confettiPieces = useMemo(() => {
     const colors = ["#e8a817", "#e74c3c", "#2ecc71", "#3498db", "#9b59b6", "#f39c12"];
@@ -113,6 +123,18 @@ export default function CelebrationStatsOverlay({
       {/* Stats */}
       <div className="celebration-stats" aria-label="Spelstatistieken">
         <div className="celebration-stat-row">
+          <span className="celebration-stat-label">Sloper</span>
+          <span className="celebration-stat-value">
+            {sloper.points > 0
+              ? `${formatNames(sloper.playerNames)} (${sloper.points} punten)`
+              : "-"}
+          </span>
+        </div>
+        <div className="celebration-stat-row">
+          <span className="celebration-stat-label">Snurker</span>
+          <span className="celebration-stat-value">{formatSnurkers()}</span>
+        </div>
+        <div className="celebration-stat-row">
           <span className="celebration-stat-label">Aantal inkopen</span>
           <span className="celebration-stat-value">{totalBuyIns}</span>
         </div>
@@ -127,20 +149,6 @@ export default function CelebrationStatsOverlay({
         <div className="celebration-stat-row">
           <span className="celebration-stat-label">Aantal ronden</span>
           <span className="celebration-stat-value">{roundCount}</span>
-        </div>
-        <div className="celebration-stat-row">
-          <span className="celebration-stat-label">Sloper</span>
-          <span className="celebration-stat-value">
-            {sloper.points > 0
-              ? `${formatNames(sloper.playerNames)} (${sloper.points} punten)`
-              : "-"}
-          </span>
-        </div>
-        <div className="celebration-stat-row">
-          <span className="celebration-stat-label">Snurker</span>
-          <span className="celebration-stat-value">
-            {snurker.rounds > 0 ? formatNames(snurker.playerNames) : "-"}
-          </span>
         </div>
       </div>
 

--- a/client/src/components/celebrationStats.test.ts
+++ b/client/src/components/celebrationStats.test.ts
@@ -110,7 +110,9 @@ describe("snurker", () => {
 
     expect(getSnurkerStat(rounds, players)).toEqual({
       rounds: 2,
-      playerNames: ["Alice"],
+      players: [
+        { playerName: "Alice", matchingRounds: 2, playedRounds: 2 },
+      ],
     });
   });
 
@@ -122,7 +124,28 @@ describe("snurker", () => {
 
     expect(getSnurkerStat(rounds, players)).toEqual({
       rounds: 1,
-      playerNames: ["Alice", "Bob", "Charlie"],
+      players: [
+        { playerName: "Alice", matchingRounds: 1, playedRounds: 2 },
+        { playerName: "Bob", matchingRounds: 1, playedRounds: 2 },
+        { playerName: "Charlie", matchingRounds: 1, playedRounds: 2 },
+      ],
+    });
+  });
+
+  it("counts played rounds per player from normal score entries only", () => {
+    const rounds = [
+      makeRound(1, { a: 1, b: 0 }, "normal"),
+      makeRound(2, { a: 1, b: 1 }, "normal"),
+      makeRound(3, { a: -2 }, "buy_in"),
+      makeRound(4, { b: 1 }, "normal"),
+    ];
+
+    expect(getSnurkerStat(rounds, players)).toEqual({
+      rounds: 2,
+      players: [
+        { playerName: "Alice", matchingRounds: 2, playedRounds: 2 },
+        { playerName: "Bob", matchingRounds: 2, playedRounds: 3 },
+      ],
     });
   });
 });

--- a/client/src/components/celebrationStats.ts
+++ b/client/src/components/celebrationStats.ts
@@ -10,9 +10,15 @@ export interface PlayerPointsStat {
   playerNames: string[];
 }
 
+export interface PlayerRoundCountEntry {
+  playerName: string;
+  matchingRounds: number;
+  playedRounds: number;
+}
+
 export interface PlayerRoundCountStat {
   rounds: number;
-  playerNames: string[];
+  players: PlayerRoundCountEntry[];
 }
 
 export function isBuyInRound(round: Round): boolean {
@@ -111,23 +117,47 @@ export function getSnurkerStat(
   players: GamePlayer[]
 ): PlayerRoundCountStat {
   const playerNames = getPlayerNameMap(players);
-  const roundsByPlayer = new Map(players.map((player) => [player.player_id, 0]));
+  const onePointRoundsByPlayer = new Map(
+    players.map((player) => [player.player_id, 0])
+  );
+  const playedRoundsByPlayer = new Map(
+    players.map((player) => [player.player_id, 0])
+  );
 
   for (const round of getNormalRounds(rounds)) {
     for (const score of round.scores) {
-      if (score.penalty_points === 1 && roundsByPlayer.has(score.player_id)) {
-        roundsByPlayer.set(
+      if (!playedRoundsByPlayer.has(score.player_id)) continue;
+
+      playedRoundsByPlayer.set(
+        score.player_id,
+        (playedRoundsByPlayer.get(score.player_id) ?? 0) + 1
+      );
+
+      if (score.penalty_points === 1) {
+        onePointRoundsByPlayer.set(
           score.player_id,
-          (roundsByPlayer.get(score.player_id) ?? 0) + 1
+          (onePointRoundsByPlayer.get(score.player_id) ?? 0) + 1
         );
       }
     }
   }
 
-  const roundCount = Math.max(0, ...roundsByPlayer.values());
+  const roundCount = Math.max(0, ...onePointRoundsByPlayer.values());
 
   return {
     rounds: roundCount,
-    playerNames: namesForTopPlayers(roundsByPlayer, playerNames, roundCount),
+    players: Array.from(onePointRoundsByPlayer.entries())
+      .filter(([, total]) => total === roundCount && roundCount > 0)
+      .map(([playerId, matchingRounds]) => {
+        const playerName = playerNames.get(playerId);
+        if (!playerName) return null;
+
+        return {
+          playerName,
+          matchingRounds,
+          playedRounds: playedRoundsByPlayer.get(playerId) ?? 0,
+        };
+      })
+      .filter((entry): entry is PlayerRoundCountEntry => Boolean(entry)),
   };
 }


### PR DESCRIPTION
### Motivation
- Improve visibility of key end-of-game stats by showing `Sloper` and `Snurker` first. 
- Provide more informative `Snurker` output by showing how many normal rounds a player had exactly one penalty and how many normal rounds they played, formatted as `(x keer van y ronden)`.
- Keep stat logic accurate by excluding buy-in rounds from the counts.

### Description
- Updated `getSnurkerStat` in `client/src/components/celebrationStats.ts` to return per-player entries with `playerName`, `matchingRounds` (one-point rounds) and `playedRounds` (normal rounds played), and to compute both counts while ignoring buy-in rounds.
- Added `PlayerRoundCountEntry` and updated `PlayerRoundCountStat` types in `celebrationStats.ts` to reflect the new shape.
- Changed `CelebrationStatsOverlay` (`client/src/components/CelebrationStatsOverlay.tsx`) to move `Sloper` and `Snurker` to the top of the stats block and to render snurker entries as `Name (x keer van y ronden)` using the new data shape.
- Updated unit tests in `client/src/components/celebrationStats.test.ts` to cover the new `Snurker` return shape, tie behavior, and the played-round counting logic.

### Testing
- Ran client unit tests with `npm test -w client` (Vitest): all tests passed (2 test files, 30 tests total).
- Built the client with `npm run build -w client`: build completed successfully.
- Ran lint with `npm run lint -w client`: lint completed successfully.
- Note: an earlier attempt using `npm test -w client -- --runInBand` failed because Vitest does not support the `--runInBand` flag, but the subsequent `npm test -w client` run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc6a70f38832494f74ddb9bd315f3)