### PR TITLE
Format ‘Meeste punten in 1 ronde’ stat to show names before points

### DIFF
--- a/client/src/components/CelebrationStatsOverlay.tsx
+++ b/client/src/components/CelebrationStatsOverlay.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { GameState } from "../api/game";
 import GameDramaGrid from "./GameDramaGrid";
 import {
+  formatMostPenaltyStat,
   getMostPenaltyStat,
   getNormalRounds,
   getSloperStat,
@@ -141,9 +142,7 @@ export default function CelebrationStatsOverlay({
         <div className="celebration-stat-row">
           <span className="celebration-stat-label">Meeste punten in 1 ronde</span>
           <span className="celebration-stat-value">
-            {mostPenalty.points > 0
-              ? `${mostPenalty.points} (${mostPenalty.playerNames.join(", ")})`
-              : "0"}
+            {formatMostPenaltyStat(mostPenalty)}
           </span>
         </div>
         <div className="celebration-stat-row">

--- a/client/src/components/GameEndCelebration.tsx
+++ b/client/src/components/GameEndCelebration.tsx
@@ -1,7 +1,11 @@
 import { useMemo } from "react";
 import type { GameState } from "../api/game";
 import GameDramaGrid from "./GameDramaGrid";
-import { getMostPenaltyStat, getNormalRounds } from "./celebrationStats";
+import {
+  formatMostPenaltyStat,
+  getMostPenaltyStat,
+  getNormalRounds,
+} from "./celebrationStats";
 
 interface GameEndCelebrationProps {
   gameState: GameState;
@@ -102,9 +106,7 @@ export default function GameEndCelebration({
         <div className="celebration-stat-row">
           <dt>Meeste punten in 1 ronde</dt>
           <dd>
-            {mostPenalty.points > 0
-              ? `${mostPenalty.points} (${mostPenalty.playerNames.join(", ")})`
-              : "0"}
+            {formatMostPenaltyStat(mostPenalty)}
           </dd>
         </div>
         <div className="celebration-stat-row">

--- a/client/src/components/celebrationStats.test.ts
+++ b/client/src/components/celebrationStats.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { GamePlayer, Round } from "../api/game";
 import {
+  formatMostPenaltyStat,
   getMostPenaltyStat,
   getNormalRounds,
   getSloperStat,
@@ -70,6 +71,19 @@ describe("celebration stats", () => {
       points: 4,
       playerNames: ["Alice", "Bob", "Charlie"],
     });
+  });
+
+  it("formats most points with player names before the point total", () => {
+    expect(
+      formatMostPenaltyStat({
+        points: 4,
+        playerNames: ["Alice", "Bob", "Charlie"],
+      })
+    ).toBe("Alice, Bob, Charlie (4)");
+  });
+
+  it("formats missing most points as zero", () => {
+    expect(formatMostPenaltyStat({ points: 0, playerNames: [] })).toBe("0");
   });
 });
 

--- a/client/src/components/celebrationStats.ts
+++ b/client/src/components/celebrationStats.ts
@@ -63,6 +63,12 @@ export function getMostPenaltyStat(
   };
 }
 
+export function formatMostPenaltyStat(stat: MostPenaltyStat): string {
+  if (stat.points <= 0 || stat.playerNames.length === 0) return "0";
+
+  return `${stat.playerNames.join(", ")} (${stat.points})`;
+}
+
 function getPlayerNameMap(players: GamePlayer[]): Map<string, string> {
   return new Map(players.map((player) => [player.player_id, player.player_name]));
 }


### PR DESCRIPTION
### Motivation

- The celebratory stats currently render the "Meeste punten in 1 ronde" value as `x (name, ...)`, but the desired format is `name, ... (x)` so player names appear first and the points are shown in parentheses. 
- Ensure consistent presentation across both celebration UI components.

### Description

- Added a shared formatter `formatMostPenaltyStat(stat: MostPenaltyStat): string` in `client/src/components/celebrationStats.ts` to render the stat as `name, name (points)` with a `0` fallback. 
- Replaced inline formatting in `client/src/components/CelebrationStatsOverlay.tsx` and `client/src/components/GameEndCelebration.tsx` to use `formatMostPenaltyStat`. 
- Added unit tests in `client/src/components/celebrationStats.test.ts` that cover the new formatted output and the zero fallback.

### Testing

- Ran the unit tests with `npm test -w client -- celebrationStats.test.ts`, which completed successfully (10 tests passed). 
- Built the client with `npm run build -w client`, which produced a successful production build. 
- Ran lint with `npm run lint -w client`, which completed without reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dca4d74e88324ac77116c0a1e5db2)