### PR TITLE
Mark winners with outline and refresh drama grid colors

### DIFF
--- a/client/src/components/GameDramaGrid.tsx
+++ b/client/src/components/GameDramaGrid.tsx
@@ -9,7 +9,6 @@ interface GameDramaGridProps {
 
 function cellPenaltyClass(cell: GridCell): string {
   if (cell.event === "dead") return "drama-cell--dead";
-  if (cell.event === "winner") return "drama-cell--winner";
   const p = cell.penalty ?? 0;
   if (p === 0) return "drama-cell--penalty-0";
   if (p === 1) return "drama-cell--penalty-1";
@@ -69,7 +68,9 @@ export default function GameDramaGrid({ gameState, excludedPlayers }: GameDramaG
             return (
               <div
                 key={colIdx}
-                className={`drama-cell ${cellPenaltyClass(cell)}`}
+                className={`drama-cell ${cellPenaltyClass(cell)} ${
+                  cell.event === "winner" ? "drama-cell--winner" : ""
+                }`}
                 title={cellTooltip(row.playerName, cell)}
               >
                 {cell.event !== "dead" && (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1134,25 +1134,25 @@ fieldset legend {
   line-height: 1;
 }
 
-/* Penalty colour tiers */
+/* Penalty colour tiers: color indicates penalty points in this round */
 .drama-cell--penalty-0 {
-  background: rgba(136, 153, 170, 0.08);
+  background: rgba(34, 197, 94, 0.2);
 }
 
 .drama-cell--penalty-1 {
-  background: rgba(241, 196, 15, 0.18);
+  background: rgba(190, 242, 100, 0.24);
 }
 
 .drama-cell--penalty-2 {
-  background: rgba(243, 156, 18, 0.28);
+  background: rgba(250, 204, 21, 0.3);
 }
 
 .drama-cell--penalty-3 {
-  background: rgba(231, 76, 60, 0.32);
+  background: rgba(249, 115, 22, 0.34);
 }
 
 .drama-cell--penalty-4 {
-  background: rgba(139, 92, 246, 0.35);
+  background: rgba(239, 68, 68, 0.4);
 }
 
 /* Special states */
@@ -1166,7 +1166,8 @@ fieldset legend {
 
 
 .drama-cell--winner {
-  background: rgba(232, 168, 23, 0.28);
+  outline: 2px solid rgba(232, 168, 23, 0.75);
+  outline-offset: -2px;
 }
 
 /* Leaderboard inside celebration */


### PR DESCRIPTION
### Motivation
- Make the winner state additive so it does not conflict with penalty background coloring and is visually distinct. 
- Refresh the penalty color palette so penalty tiers read left-to-right from green to red for clearer at-a-glance interpretation.

### Description
- Remove the `"winner"` branch from `cellPenaltyClass` and apply the `drama-cell--winner` class additively in the JSX render. 
- Update `GameDramaGrid.tsx` to append `drama-cell--winner` to the cell `className` when `cell.event === "winner"` so winner styling no longer replaces penalty backgrounds. 
- Replace the previous penalty background colors in `client/src/index.css` with a new green→yellow→orange→red ramp and add a more explicit winner style using an outline (`outline: 2px solid ...` and `outline-offset: -2px`). 
- Tweak comment text for the penalty section to clarify color semantics.

### Testing
- Ran the test suite with `yarn test`, and all tests passed. 
- Built the client with `yarn build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dcae542cc8324ba449250f2b66c11)