### PR TITLE
Heatmap cells show cumulative score, not per-round penalty (#67)

### DIFF
--- a/client/src/components/GameDramaGrid.tsx
+++ b/client/src/components/GameDramaGrid.tsx
@@ -21,11 +21,11 @@ function tierClass(cell: GridCell): string {
   return "tp-d4";
 }
 
+// The number shows the player's cumulative score AFTER that round
+// (cell.totalAfter); the cell's colour conveys the points gained that round.
 function cellText(cell: GridCell): string {
-  if (cell.event === "winner") return "★"; // ★
   if (cell.event === "dead") return "";
-  if (cell.event === "pelt") return "P";
-  return String(cell.penalty ?? 0);
+  return String(cell.totalAfter);
 }
 
 function cellTooltip(playerName: string, cell: GridCell): string {

--- a/e2e/tests/scoreboard-states.spec.ts
+++ b/e2e/tests/scoreboard-states.spec.ts
@@ -138,6 +138,13 @@ test.describe("Scoreboard states (refresh)", () => {
       .first()
       .evaluate((el) => getComputedStyle(el).backgroundColor);
     expect(d0bg).not.toBe(d4bg);
+
+    // The cell NUMBER is the cumulative score after that round (totalAfter),
+    // not the per-round penalty. Bob is at 10 after round 2 — a value that no
+    // single round's penalty reaches, so it proves score (not penalty) is shown.
+    await expect(
+      authPage.locator(".tp-dcell").filter({ hasText: /^10$/ }).first(),
+    ).toBeVisible();
   });
 
   test("reduced motion keeps the celebration winner visible", async ({


### PR DESCRIPTION
Follow-up to the #67 colour fix: the cell NUMBER regressed to the per-round penalty. It should show the player's cumulative score after that round (cell.totalAfter) — the colour already conveys the per-round penalty. Restores production's semantic (number = score, colour = points gained that round). E2E guard asserts a cell shows a cumulative value (10) unreachable by a single round's penalty.